### PR TITLE
avoid recompilation if null environment key

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.sass-lang</groupId>
     <artifactId>sass-java</artifactId>
-    <version>3.2.7.2</version>
+    <version>3.2.7.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <licenses>
@@ -16,8 +16,8 @@
     </licenses>
 
     <scm>
-        <url>https://github.com/darrinholst/sass-java</url>
-        <developerConnection>scm:git:git@github.com:darrinholst/sass-java.git</developerConnection>
+        <url>https://github.com/digaobarbosa/sass-java.git</url>
+        <developerConnection>scm:git:git@github.com:digaobarbosa/sass-java.git</developerConnection>
     </scm>
 
     <repositories>

--- a/src/main/java/com/sass_lang/SassCompilingFilter.java
+++ b/src/main/java/com/sass_lang/SassCompilingFilter.java
@@ -81,7 +81,7 @@ public class SassCompilingFilter implements Filter {
     private boolean environmentAllowsRunning() {
         if (onlyRunWhenKey != null) {
             String value = System.getProperty(onlyRunWhenKey, System.getenv(onlyRunWhenKey));
-            return value.equals(onlyRunWhenValue);
+            return onlyRunWhenValue.equalsIgnoreCase(value);
         }
         return true;
     }


### PR DESCRIPTION
Hi,
I'm using your library on my project. I did one small change on environmentsAllowRunning to avoid a NPE.

With this change, I can set the onlyRunWhenKey and onlyRunWhenValue, and the filter still works even if there is not any environment variable.

I did some more changes on the pom.xml that I don't think should be merged. I just don't know how to exclude those changes on github. :) If I have to change any thing on it, please let me know.
