### PR TITLE
Ruby bundler depends on GEM_HOME environment on CLI

### DIFF
--- a/sass-java-gems/pom.xml
+++ b/sass-java-gems/pom.xml
@@ -48,9 +48,7 @@
                                 <argument>gem</argument>
                                 <argument>install</argument>
                                 <argument>-i</argument>
-                                <argument>${project.build.directory}/jruby</argument>
-                                <argument>--no-rdoc</argument>
-                                <argument>--no-ri</argument>
+                                <argument>${project.build.directory}/bundler</argument>
                                 <argument>bundler</argument>
                             </arguments>
                         </configuration>
@@ -63,8 +61,7 @@
                         </goals>
                         <configuration>
                             <environmentVariables>
-                                <GEM_HOME>${project.build.directory}/jruby</GEM_HOME>
-                                <GEM_PATH>${project.build.directory}/jruby</GEM_PATH>
+                                <GEM_HOME>${project.build.directory}/bundler</GEM_HOME>
                             </environmentVariables>
                             <executable>java</executable>
                             <arguments>
@@ -72,7 +69,7 @@
                                 <classpath><dependency>org.jruby:jruby-complete</dependency></classpath>
                                 <argument>org.jruby.Main</argument>
                                 <argument>-S</argument>
-                                <argument>${project.build.directory}/jruby/bin/bundle</argument>
+                                <argument>${project.build.directory}/bundler/bin/bundle</argument>
                                 <argument>install</argument>
                                 <argument>--gemfile</argument>
                                 <argument>${basedir}/Gemfile</argument>


### PR DESCRIPTION
By adding this environmentVariables setting in the `pom.xml` the build process actually runs correctly on CLI without requiring to set that environment variable on the CLI.
