### PR TITLE
Old class path was still in the documentation :)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ A common practice is to turn sass generation off in production and precompile in
 ```xml
 <filter>
     <filter-name>SassCompiler</filter-name>
-    <filter-class>com.sass_lang.SassCompilingFilter</filter-class>
+    <filter-class>com.darrinholst.sass_java.SassCompilingFilter</filter-class>
     <init-param>
         <param-name>onlyRunWhenKey</param-name>
         <param-value>RUNTIME_ENVIRONMENT</param-value>


### PR DESCRIPTION
Quick fix to the documentation where old class-path was still in use.
