### PR TITLE
Bump sass to 3.4.20 and ffi 1.9.10, now compiles foundation 6

### DIFF
--- a/sass-java-gems/Gemfile
+++ b/sass-java-gems/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'compass', '1.0.1'
-gem 'sass', '3.4.4'
-gem 'ffi', '1.9.5'
+gem 'sass', '3.4.20'
+gem 'ffi', '1.9.10'

--- a/sass-java-gems/Gemfile.lock
+++ b/sass-java-gems/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    chunky_png (1.3.1)
+    chunky_png (1.3.5)
     compass (1.0.1)
       chunky_png (~> 1.2)
       compass-core (~> 1.0.1)
@@ -9,22 +9,25 @@ GEM
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
       sass (>= 3.3.13, < 3.5)
-    compass-core (1.0.1)
+    compass-core (1.0.3)
       multi_json (~> 1.0)
       sass (>= 3.3.0, < 3.5)
     compass-import-once (1.0.5)
       sass (>= 3.2, < 3.5)
-    ffi (1.9.5-java)
-    multi_json (1.10.1)
-    rb-fsevent (0.9.4)
+    ffi (1.9.10-java)
+    multi_json (1.11.2)
+    rb-fsevent (0.9.6)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
-    sass (3.4.4)
+    sass (3.4.20)
 
 PLATFORMS
   java
 
 DEPENDENCIES
   compass (= 1.0.1)
-  ffi (= 1.9.5)
-  sass (= 3.4.4)
+  ffi (= 1.9.10)
+  sass (= 3.4.20)
+
+BUNDLED WITH
+   1.11.1

--- a/sass-java-gems/src/test/java/com/darrinholst/sass_java/GemsIT.java
+++ b/sass-java-gems/src/test/java/com/darrinholst/sass_java/GemsIT.java
@@ -8,7 +8,7 @@ import static org.junit.Assert.assertEquals;
 public class GemsIT {
     @Test
     public void correctSassIsPackaged() {
-        assertEquals("3.4.4", new ScriptingContainer().runScriptlet("require 'sass';Sass.version[:number]"));
+        assertEquals("3.4.20", new ScriptingContainer().runScriptlet("require 'sass';Sass.version[:number]"));
     }
 
     @Test


### PR DESCRIPTION
Updated gems to current versions, that is sass 3.4.20 and ffi 1.9.10. Now compiles foundation 6. 